### PR TITLE
Add support for reading strings from custom section

### DIFF
--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -220,6 +220,34 @@ def get_section_strings(module, export_map, section_name):
     str_start = str_end + 1
   return asm_strings
 
+def get_wasm_custom_section(module, section_name):
+  section = module.get_custom_section(section_name)
+  if section is None:
+    logger.debug(f'no custom section found: {section_name}')
+    return {}
+
+  custom_strings = {}
+
+  module.seek(section.offset)
+  section_name = module.read_string()
+  section_name_offset = len(section_name) + 1 # +1 for uleb
+
+  start_index = 0
+  offset = section.offset + section_name_offset
+  data_size = section.size - section_name_offset
+  data = module.read_at(offset, data_size)
+
+  while start_index < data_size:
+    end_of_string_index = data.find(b'\0', start_index)
+
+    string_data = data[start_index:end_of_string_index]
+    string_key = str(1028 # TODO: fix this. Offset depends on some factors I don't know
+                      + start_index)
+    custom_strings[string_key] = data_to_string(string_data)
+    
+    start_index = end_of_string_index + 1
+
+  return custom_strings
 
 def get_main_reads_params(module, export_map):
   if settings.STANDALONE_WASM:
@@ -348,6 +376,8 @@ def extract_metadata(filename):
     metadata.function_exports = get_function_exports(module)
     metadata.all_exports = [utils.removeprefix(e.name, '__em_js__') for e in exports]
     metadata.asmConsts = get_section_strings(module, export_map, 'em_asm')
+    custom_asmConsts = get_wasm_custom_section(module, 'em_asm')
+    metadata.asmConsts.update(custom_asmConsts)
     metadata.jsDeps = [d for d in get_section_strings(module, export_map, 'em_lib_deps').values() if d]
     metadata.emJsFuncs = em_js_funcs
     metadata.emJsFuncTypes = em_js_func_types


### PR DESCRIPTION
In this commit, we introduce functionality to read strings from a custom section in WebAssembly modules. This is crucial for enabling Rust code to work seamlessly with Emscripten, as Rust writes to custom sections rather than the em_asm section (https://github.com/emscripten-core/emscripten/issues/13838#issuecomment-820656350).

The changes made in this commit include:
- The addition of the `get_wasm_custom_section` function, which retrieves custom sections by name from a WebAssembly module.
- Reading and parsing strings from the specified custom section.
- Storing the extracted strings in a dictionary for further processing.

This enhancement addresses an issue #13838 where Rust code interacts with Emscripten, and the ability to read strings from custom sections is necessary for proper integration.

This is a work in progress, as we still need to determine the correct offset value for the `string_key` variable.

Please note that this commit depends on the changes introduced in Merge Request #20218.